### PR TITLE
Make hostname validation compatible with kubernetes ingresses

### DIFF
--- a/src/main/scala/kubeyml/ingress/Protocol.scala
+++ b/src/main/scala/kubeyml/ingress/Protocol.scala
@@ -59,8 +59,15 @@ case class Spec(rules: List[Rule])
 sealed trait Rule
 
 case class Host(value: String) {
+  private def errorMessage = s""""
+    Invalid value: ${value}:
+    a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.',
+    and must start and end with an alphanumeric character
+    (e.g. 'example.com', regex used for validation is
+    '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+  """
   require(value.nonEmpty, "Hostname cannot be empty")
-  require(value.matches("([a-zA-Z0-9\\-_]+\\.?)*"), s"Hostname has a wrong format ${value}")
+  require(value.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"), errorMessage)
 }
 
 case class HttpRule(host: Host, paths: List[Path]) extends Rule

--- a/src/main/scala/kubeyml/ingress/Protocol.scala
+++ b/src/main/scala/kubeyml/ingress/Protocol.scala
@@ -59,15 +59,16 @@ case class Spec(rules: List[Rule])
 sealed trait Rule
 
 case class Host(value: String) {
+  private val validationRegex = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
   private def errorMessage = s""""
     Invalid value: ${value}:
     a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.',
     and must start and end with an alphanumeric character
     (e.g. 'example.com', regex used for validation is
-    '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+    '${validationRegex}')
   """
   require(value.nonEmpty, "Hostname cannot be empty")
-  require(value.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"), errorMessage)
+  require(value.matches(s"${validationRegex}"), errorMessage)
 }
 
 case class HttpRule(host: Host, paths: List[Path]) extends Rule

--- a/src/test/scala/kubeyml/ingress/KubernetesComponents.scala
+++ b/src/test/scala/kubeyml/ingress/KubernetesComponents.scala
@@ -48,6 +48,9 @@ trait KubernetesComponents {
   private val arbitraryNonEmptyString: Gen[NonEmptyString] =
     Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString).map(NonEmptyString)
 
+  private val arbitraryNonEmptyLowercaseString: Gen[NonEmptyString] =
+    Gen.nonEmptyListOf(Gen.alphaLowerChar).map(_.mkString).map(NonEmptyString)
+
   private val pathVariableGen: Gen[PathVariable] = for {
     serviceName <- arbitraryNonEmptyString.map(_.value)
     servicePort <- Gen.chooseNum(0, 65535)
@@ -55,10 +58,8 @@ trait KubernetesComponents {
   } yield PathVariable(serviceName, servicePort, path)
 
   private val hostnameWordGen: Gen[String] =
-    Gen.oneOf(
-      Gen.nonEmptyListOf(arbitraryNonEmptyString.map(_.value)).map(_.mkString("-")),
-      Gen.nonEmptyListOf(arbitraryNonEmptyString.map(_.value)).map(_.mkString("_")),
-    )
+      Gen.nonEmptyListOf(arbitraryNonEmptyLowercaseString.map(_.value)).map(_.mkString("-"))
+
 
   private val ruleVariableGen: Gen[RuleVariable] = for {
     host <- Gen.oneOf(


### PR DESCRIPTION
Hostnames that previously were valid (with upper case characters or underscores will no longer be valid)